### PR TITLE
Fix #97 by allowing either plain link.res or link{pid}.res file.

### DIFF
--- a/custom_link.sh
+++ b/custom_link.sh
@@ -14,9 +14,9 @@ if [[ $1 == *"linux"* ]]; then
 else
     echo '-alias_list' >> "$resfile"
     echo 'src/darwin_alias_list.txt' >> "$resfile"
-    cut -d " " -f 2 'src/darwin_alias_list.txt' >> $1/linksyms.fpc
+    cut -d " " -f 2 'src/darwin_alias_list.txt' >> "$1"/linksyms.fpc
 fi
 
-$1/ppas.sh
-rm -f $1/ppas.sh "$resfile" $1/linksyms.fpc
+"$1"/ppas.sh
+rm -f "$1"/ppas.sh "$resfile" "$1"/linksyms.fpc
 

--- a/custom_link.sh
+++ b/custom_link.sh
@@ -5,16 +5,18 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
+resfile=$(ls "$1"/*.res)
+
 if [[ $1 == *"linux"* ]]; then
-    sed -i 's/\(      LoadShapes_Set_Sinterval;\)/\1\n      LoadShapes_Set_SInterval;/' $1/link.res 
-    sed -i 's/\(      LoadShapes_Get_sInterval;\)/\1\n      LoadShapes_Get_SInterval;/' $1/link.res 
-    sed -i 's/\(^VERSION$\)/LoadShapes_Set_SInterval = LoadShapes_Set_Sinterval;\nLoadShapes_Get_SInterval = LoadShapes_Get_sInterval;\n\1/' $1/link.res 
+    sed -i 's/\(      LoadShapes_Set_Sinterval;\)/\1\n      LoadShapes_Set_SInterval;/' "$resfile"
+    sed -i 's/\(      LoadShapes_Get_sInterval;\)/\1\n      LoadShapes_Get_SInterval;/' "$resfile"
+    sed -i 's/\(^VERSION$\)/LoadShapes_Set_SInterval = LoadShapes_Set_Sinterval;\nLoadShapes_Get_SInterval = LoadShapes_Get_sInterval;\n\1/' "$resfile"
 else
-    echo '-alias_list' >> $1/link.res
-    echo 'src/darwin_alias_list.txt' >> $1/link.res
+    echo '-alias_list' >> "$resfile"
+    echo 'src/darwin_alias_list.txt' >> "$resfile"
     cut -d " " -f 2 'src/darwin_alias_list.txt' >> $1/linksyms.fpc
 fi
 
 $1/ppas.sh
-rm -f $1/ppas.sh $1/link.res $1/linksyms.fpc
+rm -f $1/ppas.sh "$resfile" $1/linksyms.fpc
 


### PR DESCRIPTION
This patch has been tested under Linux with fpc 3.2.2 (and verified to also work with fpc 3.2.0) but not under MacOS yet.